### PR TITLE
rfr-12 Integrate Dagger 2 lib

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ ext {
     retrofitVersion = '2.1.0'
     firebaseVersion = '9.4.0'
     playServicesVersion = '9.4.0'
+    daggerVersion = '2.5'
 }
 
 dependencies {
@@ -38,6 +39,10 @@ dependencies {
 
     compile "com.jakewharton:butterknife:$butterKnifeVersion"
     apt "com.jakewharton:butterknife-compiler:$butterKnifeVersion"
+
+    apt "com.google.dagger:dagger-compiler:$daggerVersion"
+    compile "com.google.dagger:dagger:$daggerVersion"
+    provided 'javax.annotation:jsr250-api:1.0'
 
     //retrofit
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/app/src/main/java/rss/feed/reader/RssFeedReaderApp.java
+++ b/app/src/main/java/rss/feed/reader/RssFeedReaderApp.java
@@ -5,6 +5,10 @@ import android.app.Application;
 import com.google.android.gms.analytics.GoogleAnalytics;
 import com.google.android.gms.analytics.Tracker;
 
+import rss.feed.reader.dagger.components.AppComponent;
+import rss.feed.reader.dagger.components.DaggerAppComponent;
+import rss.feed.reader.dagger.modules.AppModule;
+
 /**
  * App class.
  * Created by vkravets on 8/31/2016.
@@ -15,6 +19,7 @@ public class RssFeedReaderApp extends Application {
      * Application instance.
      */
     private static RssFeedReaderApp sInstance;
+    private AppComponent mAppComponent;
 
     private Tracker mTracker;
 
@@ -25,6 +30,10 @@ public class RssFeedReaderApp extends Application {
 
         GoogleAnalytics analytics = GoogleAnalytics.getInstance(getApplicationContext());
         mTracker = analytics.newTracker(R.xml.global_tracker);
+
+        mAppComponent = DaggerAppComponent.builder()
+                .appModule(new AppModule(this))
+                .build();
     }
 
     /**
@@ -36,5 +45,9 @@ public class RssFeedReaderApp extends Application {
 
     public Tracker getTracker() {
         return mTracker;
+    }
+
+    public AppComponent getAppComponent() {
+        return mAppComponent;
     }
 }

--- a/app/src/main/java/rss/feed/reader/dagger/Stub.java
+++ b/app/src/main/java/rss/feed/reader/dagger/Stub.java
@@ -1,9 +1,0 @@
-package rss.feed.reader.dagger;
-
-/**
- * .
- * Created by vkravets on 8/31/2016.
- */
-public class Stub {
-
-}

--- a/app/src/main/java/rss/feed/reader/dagger/components/ActivityComponent.java
+++ b/app/src/main/java/rss/feed/reader/dagger/components/ActivityComponent.java
@@ -1,0 +1,18 @@
+package rss.feed.reader.dagger.components;
+
+import android.app.Activity;
+
+import dagger.Component;
+import rss.feed.reader.dagger.modules.ActivityModule;
+import rss.feed.reader.dagger.scopes.ActivityScope;
+
+/**
+ * Created by Orest Guziy on 16.09.16.
+ */
+@ActivityScope
+@Component(dependencies = {AppComponent.class}, modules = {ActivityModule.class})
+public interface ActivityComponent {
+
+    Activity activity();
+
+}

--- a/app/src/main/java/rss/feed/reader/dagger/components/AppComponent.java
+++ b/app/src/main/java/rss/feed/reader/dagger/components/AppComponent.java
@@ -1,0 +1,24 @@
+package rss.feed.reader.dagger.components;
+
+import android.content.Context;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
+import rss.feed.reader.RssFeedReaderApp;
+import rss.feed.reader.dagger.modules.AppModule;
+
+/**
+ * Singleton-based app component
+ * <p/>
+ * Created by Orest Guziy on 16.09.16.
+ */
+@Singleton
+@Component(modules = {AppModule.class})
+public interface AppComponent {
+
+    Context appContext();
+
+    RssFeedReaderApp app();
+
+}

--- a/app/src/main/java/rss/feed/reader/dagger/modules/ActivityModule.java
+++ b/app/src/main/java/rss/feed/reader/dagger/modules/ActivityModule.java
@@ -1,0 +1,27 @@
+package rss.feed.reader.dagger.modules;
+
+import android.app.Activity;
+
+import dagger.Module;
+import dagger.Provides;
+import rss.feed.reader.dagger.scopes.ActivityScope;
+
+/**
+ * Created by Orest Guziy on 16.09.16.
+ */
+@Module
+public class ActivityModule {
+
+    private final Activity mActivity;
+
+    public ActivityModule(Activity activity) {
+        mActivity = activity;
+    }
+
+    @Provides
+    @ActivityScope
+    public Activity providesActivity() {
+        return mActivity;
+    }
+
+}

--- a/app/src/main/java/rss/feed/reader/dagger/modules/AppModule.java
+++ b/app/src/main/java/rss/feed/reader/dagger/modules/AppModule.java
@@ -1,0 +1,30 @@
+package rss.feed.reader.dagger.modules;
+
+import android.content.Context;
+
+import dagger.Module;
+import dagger.Provides;
+import rss.feed.reader.RssFeedReaderApp;
+
+/**
+ * Created by Orest Guziy on 16.09.16.
+ */
+@Module
+public class AppModule {
+
+    private final RssFeedReaderApp mApp;
+
+    public AppModule(RssFeedReaderApp app) {
+        mApp = app;
+    }
+
+    @Provides
+    public Context providesAppContext() {
+        return mApp.getApplicationContext();
+    }
+
+    @Provides
+    public RssFeedReaderApp providesApp() {
+        return mApp;
+    }
+}

--- a/app/src/main/java/rss/feed/reader/dagger/scopes/ActivityScope.java
+++ b/app/src/main/java/rss/feed/reader/dagger/scopes/ActivityScope.java
@@ -1,0 +1,18 @@
+package rss.feed.reader.dagger.scopes;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Scope;
+
+/**
+ * Custom Dagger 2 scope that is used to separate activity- and application-level dependencies
+ * <p/>
+ * Created by Orest Guziy on 16.09.16.
+ */
+@Scope
+@Documented
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface ActivityScope {
+}

--- a/app/src/main/java/rss/feed/reader/ui/base/BaseActivity.java
+++ b/app/src/main/java/rss/feed/reader/ui/base/BaseActivity.java
@@ -7,6 +7,11 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
 import rss.feed.reader.Navigation;
+import rss.feed.reader.RssFeedReaderApp;
+import rss.feed.reader.dagger.components.ActivityComponent;
+import rss.feed.reader.dagger.components.AppComponent;
+import rss.feed.reader.dagger.components.DaggerActivityComponent;
+import rss.feed.reader.dagger.modules.ActivityModule;
 
 /**
  * Base activity class.
@@ -14,15 +19,29 @@ import rss.feed.reader.Navigation;
  */
 public class BaseActivity extends AppCompatActivity implements Navigation.ActivityStarter {
 
+    private ActivityComponent mActivityComponent;
+
     @Override
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         // extra code here..
+        mActivityComponent = DaggerActivityComponent.builder()
+                .appComponent(getAppComponent())
+                .activityModule(new ActivityModule(this))
+                .build();
     }
 
     @Override
     public Intent createIntent(@NonNull final Class<?> cls) {
         return new Intent(this, cls);
+    }
+
+    private AppComponent getAppComponent() {
+        return RssFeedReaderApp.getInstance().getAppComponent();
+    }
+
+    public ActivityComponent getActivityComponent() {
+        return mActivityComponent;
     }
 }


### PR DESCRIPTION
Add Dagger 2 dependency, add skeleton for dependency injection

NOTE: As Dagger 2 does't allow to override the injections (e.g. Context for app and activity) then I used Activity injection as Activity Context injection.